### PR TITLE
Update Merlin to stable version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.14"
 features = ["u128-support"]
 
 [dependencies]
-merlin = "0.2"
+merlin = "1"
 rand = "0.4"
 bellman = "*"
 


### PR DESCRIPTION
This is required to build the crate since I yanked the prerelease versions of Merlin a little while ago.